### PR TITLE
chore: use new env vars for docker hub publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -41,6 +41,6 @@ jobs:
           fi
 
           registry=registry.hub.docker.com
-          echo "${{ secrets.DOCKER_PASSWORD }}" | docker login $registry -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          echo "${{ secrets.DSV_DOCKER_PASSWORD }}" | docker login $registry -u ${{ secrets.DSV_DOCKER_USERNAME }} --password-stdin
           make release REGISTRY="delineaopensource" VERSION=$version
           docker logout

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 ---
-name: Tests
+name: go-tests
 on:
   push:
     # Publish `main` as Docker `latest` image.


### PR DESCRIPTION
Adjust vars to new values to use for publishing to DockerHub.
This uses a generated token instead of permanent credentials for better scoping and auditing.

- Related [AB#450405](https://thycotic.visualstudio.com/4a89362e-1361-424f-a291-a8f57c2a8991/_workitems/edit/450405)
- fixes [AB#450818](https://thycotic.visualstudio.com/4a89362e-1361-424f-a291-a8f57c2a8991/_workitems/edit/450818)