### PR TITLE
docs: 📘 improve docs readability and organization

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH" # for those using aqua this will ensure it's in the path with all tools if loading from home
+# export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH" # for those using aqua this will ensure it's in the path with all tools if loading from home
 export DIRENV_WARN_TIMEOUT='10s'
 export DIRENV_LOG_FORMAT=""
 

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -2,7 +2,7 @@ version: 0.1
 plugins:
   sources:
     - id: trunk
-      ref: v0.0.8
+      ref: v0.0.9
       uri: https://github.com/trunk-io/plugins
 actions:
   enabled:
@@ -44,20 +44,23 @@ runtimes:
           value: 1
   enabled: [go@1.19, node@16.14.2, python@3.10.3]
 cli:
-  version: 1.3.2
+  version: 1.4.1
 lint:
+  threshold:
+    - linters: [gitleaks]
+      level: high
   disabled:
     - cspell
   enabled:
     #- cspell@6.19.2
-    - prettier@2.3.0
+    - prettier@2.8.3
     - git-diff-check
     - taplo@0.7.0
     - yamllint@1.29.0
     - actionlint@1.6.23
     - gitleaks@8.15.3
     - gofmt@1.19.3
-    - golangci-lint@1.50.1
+    - golangci-lint@1.51.0
     - hadolint@2.12.0
     - markdownlint@0.33.0
     # - prettier@2.8.3

--- a/README.md
+++ b/README.md
@@ -16,29 +16,36 @@
 
 [![Red Hat Quay](https://quay.io/repository/delinea/dsv-k8s/status 'Red Hat Quay')](https://quay.io/repository/delinea/dsv-k8s)
 
-A [Kubernetes](https://kubernetes.io/)
-[Mutating Webhook](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks)
-that injects Secret data from Delinea DevOps Secrets Vault (DSV) into Kubernetes Secrets and a [CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/)
-that subsequently periodically synchronizes them from the source, DSV.
-The webhook can be hosted as a pod or as a stand-alone service.
-Likewise, the cronjob can run inside or outside the cluster.
-The webhook intercepts `CREATE` Secret admissions and then mutates the Secret with data from DSV.
-The syncer scans the cluster (or a single namespace) for Secrets that were mutated and,
-upon finding a mutated secret,
-it compares the version of the DSV Secret with the version it was mutated with and,
-if the version in DSV is newer, then the mutation is repeated.
-The common configuration consists of one or more Client Credential Tenant mappings.
-The credentials are then specified in an [Annotation](https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/)
-on the Kubernetes Secret to be mutated.
-See [below](#use).
+The DSV Kubernetes Injector and Syncer are components for [Kubernetes][kubernetes].
+The [Mutating Webhook][mutating-webhook] injects Secret data from the Delinea DevOps Secrets Vault (DSV) into Kubernetes Secrets, and a CronJob periodically synchronizes them.
+The webhook can run as a pod or a stand-alone service, and the cronjob can run inside or outside the cluster.
 
-The webhook and syncer use the [Golang SDK](https://github.com/DelineaXPM/dsv-sdk-go)
-to communicate with the DSV API.
-They were tested with [Docker Desktop](https://www.docker.com/products/docker-desktop/)
-and [Minikube](https://minikube.sigs.k8s.io/).
-They also work on [OpenShift](https://www.redhat.com/en/technologies/cloud-computing/openshift),
-[Microk8s](https://microk8s.io/)
-and others.
+- `dsv-injector`: Intercepts `CREATE` Secret admissions and then mutates the Secret with data from DSV.
+- `dsv-syncer`: The syncer scans the cluster (or a single namespace) for Secrets that were mutated, compares the secret version, and updates if the secret has changed versions.
+
+The common configuration consists of one or more Client Credential Tenant mappings.
+The credentials are then specified in an [Annotation][annotation] on the Kubernetes Secret to be mutated.
+
+The webhook and syncer use the [Golang SDK][dsv-go-sdk] to communicate with the DSV API.
+They were tested with [Docker Desktop][docker-desktop] and [Minikube][minikube].
+They also work on [OpenShift][openshift], [Microk8s][microk8s] and others.
+
+## Contents
+
+- [Delinea DevOps Secrets Vault Kubernetes Secret Injector and Syncer](#delinea-devops-secrets-vault-kubernetes-secret-injector-and-syncer)
+  - [Contents](#contents)
+  - [Supporting Docs](#supporting-docs)
+  - [Injector \& Syncer Differences](#injector--syncer-differences)
+    - [Which Should I Use?](#which-should-i-use)
+  - [Quick Start](#quick-start)
+    - [Build](#build)
+  - [Test](#test)
+  - [Reference Mage Tasks](#reference-mage-tasks)
+  - [Contributors](#contributors)
+
+## Supporting Docs
+
+The [docs](docs/) directory has supporting documentation that goes into more detail on the developer workflows, test setup, configuration, helm install commands, and more.
 
 ## Injector & Syncer Differences
 
@@ -48,7 +55,7 @@ and others.
 - Syncer: In contrast, the syncer is a normal cronjob operating on a schedule, checking for any variance in the data
   between the Secret data between the resource in Kubernetes and the expected value from DSV.
 
-## Which Should I Use?
+### Which Should I Use?
 
 - Both: If you want a secret to be injected on creation and also synced on your cron schedule then use the Injector and Syncer.
 - Injector: If you want the secret to be static despite the change upstream in DSV, and will recreate the secret on any need to upgrade, then the injector.
@@ -57,474 +64,67 @@ and others.
   If this is run by itself without the injector, there can be a lag of up to a minute before the syncer will update the secret.
   Your application should be able to handle retrying the load of the credential to avoid using the cached credential value that might have been loaded on app start-up in this case.
 
-## Local Development Tooling
+## Quick Start
 
-- Make: Makefiles provide core automation.
-- Mage: Mage is a Go based automation alternative to Make and provides newer functionality for local Kind cluster setup, Go development tooling/linting, and more.
-  Requires Go 17+ and is easily installed via: `go install github.com/magefile/mage@latest`.
-  Run `mage -l` to list all available tasks, and `mage init` to setup developer tooling.
-- Pre-Commit: Requires Python3. Included in project, this allows linting and formatting automation before committing, improving the feedback loop.
-- Optional:
-  - Devcontainer configuration included for VSCode to work with Devcontainers and Codespaces in a pre-built development environment that works on all platforms, and includes nested Docker and ability to run Kind kubernetes clusters without any installing any of those on the Host OS.
-- Direnv: Default test values are loaded on macOS/Linux based system using [direnv](https://direnv.net/docs/installation.html).
-  Run `direnv allow` in the directory to load default env configuration for testing.
-- macOS/Linux: [Trunk.io](https://trunk.io/) to provide linting and formatting on the project.
-  Included in recommended extensions.
-- `trunk install`, `trunk check`, and `trunk fmt` simplifies running checks.
+Since there's a mix of users for this repo, here's where to go for getting up and running as quickly as possible.
 
-## List of Mage Tasks
-
-- `mage -l` will give you a list of tasks.
-- `mage -h init` provides more help detail on a task when it's available.
-
-## Configure
-
-The configuration requires a JSON formatted list of Client Credential and Tenant mappings.
-
-```json
-{
-  "app1": {
-    "credentials": {
-      "clientId": "93d866d4-635f-4d4e-9ce3-0ef7f879f319",
-      "clientSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxx-xxxxx"
-    },
-    "tenant": "mytenant"
-  },
-  "default": {
-    "credentials": {
-      "clientId": "64241412-3934-4aed-af26-95b1eaba0e6a",
-      "clientSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxx-xxxxx"
-    },
-    "tenant": "mytenant"
-  }
-}
-```
-
-> **_note_**
-> the injector uses the _default_ credentials when mutating a Kubernetes Secret without a _credentialAnnotation_.
-> See [below](#use)
-
-## Local
-
-### Run
-
-The injector uses the HTTPS server built-in to the Golang [http](https://pkg.go.dev/net/http)
-package to host the Kubernetes Mutating Webhook Webservice.
-
-```bash
-$ ./dsv-injector -h
-Usage of ./dsv-injector:
-  -address string
-        the address to listen on, e.g., 'localhost:8080' or ':8443' (default ":18543")
-  -cert string
-        the path of the public certificate file in PEM format (default "tls/cert.pem")
-  -credentials string
-        the path of JSON formatted credentials file (default "credentials/config.json")
-  -key string
-        the path of the private key file in PEM format (default "tls/key.pem")
-```
-
-Thus the injector can run "anywhere," but, typically,
-the injector runs as a POD in the Kubernetes cluster that uses it.
-The syncer is a simple Golang executable.
-It typically runs as a Kubernetes CronJob, but it will run outside the cluster.
-
-```bash
-$ ./dsv-syncer -h
-Usage of ./dsv-syncer:
-  -credentials string
-        the path of JSON formatted credentials file (default "credentials/config.json")
-  -kubeConfig string
-        the Kubernetes Client API configuration file; ignored when running in-cluster (default "/home/user/.kube/config")
-  -namespace string
-        the Kubernetes namespace containing the Secrets to sync; "" (the default) for all namespaces
-```
+| Who                                                               | Where do I start?                                           |
+| ----------------------------------------------------------------- | ----------------------------------------------------------- |
+| 👉 I just want to install the helm charts against my own cluster. | Clone, and use `helm install` against the charts directory. |
+| 👉 I want to test against a disposable local kubernetes first.    | Use the [local-kubernetes](docs/local-kubernetes.md) guide. |
+| 👉 I'm a contributor/developer.                                   | Use the [setup-developer](docs/setup-developer.md) guide.   |
+| 👉 I'm a contributor and need to create a release.                | Use the [release](docs/release.md) guide.                   |
 
 ### Build
 
-> **_note_**
-> Building the `dsv-injector` image is not required to install it as it is.
-> It is available on multiple public registries.
-> Building the image requires [Docker](https://www.docker.com/) or [Podman](https://podman.io/) and [GNU Make](https://www.gnu.org/software/make/).
+<img src="docs/assets/random-dont-need-to-install.svg">
 
-To build it, run: `make`.
+To build run: `mage init build`.
+For more detailed directions on local development (such as Mage), see [setup-developer](docs/setup-developer.md)
 
-This will build the injector and syncer as platform binaries and store them in the project root.
-It will also build the image (which will build and store its own copy of the binaries) using `$(DOCKER)`.
+## Test
 
-### Test
-
-The tests expect a few environmental conditions to be met.
-
-> **_note_**
-> For more detailed setup see collapsed section below for DSV Test Configuration Setup.
-
-- A valid DSV tenant.
-- A secret created with the data format below:
-  {
-  "data": {
-  "password": "admin",
-  "username": "admin"
-  },
-  "version": "0"
-  }
-- A `configs/credentials.json` to be created manually that contains the client credentials.
-- The `configs/credentials.json` credential to be structured like this:
-
-  {
-  "app1": {
-  "credentials": {
-  "clientId": "",
-  "clientSecret": ""
-  },
-  "tenant": "app1"
-  }
-  }
-
-> **_warning_** > `app1` is required and using any other will fail test conditions.
-
-<details closed>
-<summary>🧪 DSV Test Configuration Setup</summary>
-
-- Using dsv cli (grab from [downloads](https://dsv.secretsvaultcloud.com/downloads) and install with snippet adjusted to version: `$(curl -fSSL https://dsv.secretsvaultcloud.com/downloads/cli/1.35.2/dsv-linux-x64 -o ./dsv-linux-x64 && chmod +x ./dsv-linux-x64 && sudo mv ./dsv-linux-x64 /usr/local/bin/dsv && dsv --version`
-- Run `dsv init` (Use a local user)
-- Create the role that will allow creating a client for programmatic access: `dsv role create --name 'k8s' --desc 'test profile for k8s'`
-- `dsv secret create --path 'k8s:sync:test' --data '{"password": "admin","username": "admin"}'`
-- Create a policy that allows the local user to read the secret, modify this to the correct user/group mapping: `dsv policy create -- actions 'read' --path 'secrets:k8s' --desc 'test access to secret' --resources 'secrets:k8s:<.*>' --subjects 'roles:k8s'`
-- Create the client: `dsv client create --role k8s`
-- Use those credentials in the structure mentioned above.
-
-</details>
-
-To invoke the tests, run:
-
-```sh
-make test
-```
-
-Set `$(GO_TEST_FLAGS)` to `-v` to get DEBUG output.
-They require a `credentials.json` as either a file or a string.
-They also require the path to a secret to test to use.
-Use environment variables to specify both:
-
-| Environment Variable       | Default                          | Explanation                                                 |
-| -------------------------- | -------------------------------- | ----------------------------------------------------------- |
-| `DSV_K8S_TEST_CONFIG`      | _none_                           | Contain a JSON string containing a valid `credentials.json` |
-| `DSV_K8S_TEST_CONFIG_FILE` | `../../configs/credentials.json` | The path to a valid `credentials.json`                      |
-| `DSV_K8S_TEST_SECRET_PATH` | `/test/secret`                   | The path to the secret to test against in the vault         |
-
-ℹ️ NOTE: `DSV_K8S_TEST_CONFIG` takes precedence over `DSV_K8S_TEST_CONFIG_FILE`
-
-For example:
-
-```sh
-DSV_K8S_TEST_CONFIG='{"app1":{"credentials":{"clientId":"93d866d4-635f-4d4e-9ce3-0ef7f879f319","clientSecret":"xxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxx-xxxxx"},"tenant":"mytenant"}}' \
-DSV_K8S_TEST_SECRET_PATH=my:test:secret \
-make test GO_TEST_FLAGS='-v'
-```
-
-To remove the binaries and Docker image so that the next build is from scratch, run:
-
-```sh
-make clean
-```
-
-For Go development, another option is to run gotestsum (installed automatically with `mage init`) with a filewatch option to get regular test output:
-
-```shell
-gotestsum --format dots-v2 --watch ./... -- -v
-```
-
-## Install
-
-Installation requires [Helm](https://helm.sh).
-There are two separate charts for the injector and the syncer.
-The `Makefile` demonstrates a typical installation of both.
-The dsv-injector chart imports `credentials.json` from the filesystem and stores it in a Kubernetes Secret.
-The dsv-syncer chart refers to that Secret instead of creating its own.
-The Helm `values.yaml` file `image.repository` is `quay.io/delinea/dsv-k8s`:
-
-```yaml
-image:
-  repository: quay.io/delinea/dsv-k8s
-  pullPolicy: IfNotPresent
-  # Overrides the image tag whose default is the chart appVersion.
-tag: ''
-```
-
-That means, by default, `make install` will pull from Red Hat Quay.
-
-```sh
-make install
-```
-
-However,
-the `Makefile` contains an `install-image` target that configures Helm to use the image built with `make image`:
-
-```sh
-make install-image
-```
-
-`make uninstall` uninstalls the Helm Charts.
-
-### Docker Desktop
-
-To install the locally built image into Docker Desktop, run:
-
-```sh
-make install-image
-```
-
-ℹ️ NOTE: Kubernetes must be [enabled](https://docs.docker.com/desktop/kubernetes/)
-for this to work.
-
-### Remote Cluster
-
-Deploying the locally built image into a remote Cluster will require a container registry.
-The container registry must be accessible from the build and the cluster by the same DNS name.
-`make` will run the `release` target, which will push the image into the container registry,
-`install-cluster` will cause the cluster to pull it from there.
-
-```sh
-make install-cluster REGISTRY=internal.example.com:5000
-```
-
-### Minikube
-
-#### Docker driver
-
-To deploy to Minikube running on the [Docker driver](https://minikube.sigs.k8s.io/docs/drivers/docker/),
-run `eval $(minikube docker-env)` so that the environment shares Minikube's docker context,
-then follow the [Docker Desktop](#docker-desktop)
-instructions.
-
-#### VM driver
-
-To deploy to Minikube set-up with the VM driver, e.g., Linux [kvm2](https://minikube.sigs.k8s.io/docs/drivers/kvm2/)
-or Microsoft [Hyper-V](https://minikube.sigs.k8s.io/docs/drivers/hyperv/),
-enable the Minikube built-in registry and use it to make the image available to the Minikube VM:
-
-```sh
-minikube addons enable registry
-```
-
-❗NOTE: run Minikube [tunnel](https://minikube.sigs.k8s.io/docs/commands/tunnel/)
-in a separate terminal to make the registry service available to the host.
-
-```sh
-minikube tunnel
-```
-
-_It will run continuously, and stopping it will render the registry inaccessible._
-
-Next, get the _host:port_ of the registry:
-
-```sh
-kubectl get -n kube-system service registry -o jsonpath="{.spec.clusterIP}{':'}{.spec.ports[0].port}"
-```
-
-Finally, follow the [Remote Cluster](#remote-cluster)
-instructions using it as `$(REGISTRY)`
-
-### Kind
-
-For local development, Mage tasks have been created to automate most of the setup and usage for local testing.
-
-- Run `mage init` to setup dev tooling.
-- Ensure your local `configs/credentials.json` exists.
-- run `mage kind:init k8s:init helm:init` to setup a local kind cluster, initial local copies of the helm chart and kubernetes manifest files.
-- Modify the `.cache/dsv-injector/values.yaml` with the embedded credentials.json contents matching your `configs/credentials.json`.
-- Modify the `.cache/manifests/*.yaml` files to match the credentials you want to test against.
-- To deploy (or redeploy after changes) all the helm charts and kuberenetes manifests run `mage job:redeploy`.
-
-### Host (for debugging)
-
-Per above, typically, the injector runs as a POD in the cluster but running it on the host makes debugging easier.
-
-```sh
-make install-host EXTERNAL_NAME=laptop.mywifi.net CA_BUNDLE=$(cat /path/to/ca.crt | base64 -w0 -)
-```
-
-For it to work:
-
-- The certificate that the injector presents must validate against the `$(CA_BUNDLE)`.
-- The certificate must also have a Subject Alternative Name for `$(INJECTOR_NAME).$(NAMESPACE).svc`.
-  By default that's `dsv-injector.dsv.svc`.
-
-- The `$(EXTERNAL_NAME)` is a required argument, and the name itself must be resolvable _inside_ the cluster.
-  **localhost will not work**.
-
-If the `$(CA_BUNDLE)` is argument is omitted, `make` will attempt to extract it from `kubectl config`:
-
-```make
-install-host: CA_BUNDLE_KUBE_CONFIG_INDEX = 0
-install-host: CA_BUNDLE_JSON_PATH = {.clusters[$(CA_BUNDLE_KUBE_CONFIG_INDEX)].cluster.certificate-authority-data}
-install-host: CA_BUNDLE=$(shell $(KUBECTL) config view --raw -o jsonpath='$(CA_BUNDLE_JSON_PATH)' | tr -d '"')
-
-```
-
-which will make:
-
-```sh
-kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | tr -d '"'
-```
-
-Optionally set `$(CA_BUNDLE_KUBE_CONFIG_INDEX)` to use `1`, to use the second cluster in your configuration,
-`2` for the third and so on.
-ℹ️ All this assumes that the injector uses a certificate signed by the cluster CA.
-There are several options like [cert-manager](https://cert-manager.io/)
-for getting cluster-signed certs, however,
-this simple [bash script](https://gist.github.com/amigus/b4e6e642f88e756be1996e44a1c35349)
-will request and grant a suitable certificate from the cluster using cURL and OpenSSL.
-To use it:
-
-```sh
-get_k8s_cert.sh -n dsv-injector -N dsv
-```
-
-Now run it:
-
-```sh
-./dsv-injector -cert ./dsv-injector.pem -key ./dsv-injector.key -credentials ./configs/credentials.json -address :8543
-```
-
-## Use
-
-Once the injector is available in the Kubernetes cluster,
-and the webhook is in place,
-any correctly annotated Kubernetes Secrets are modified on create and update.
-The four annotations that affect the behavior of the webhook are:
-
-```golang
-const(
-    credentialsAnnotation = "dsv.delinea.com/credentials"
-    setAnnotation         = "dsv.delinea.com/set-secret"
-    addAnnotation         = "dsv.delinea.com/add-to-secret"
-    updateAnnotation      = "dsv.delinea.com/update-secret"
-)
-```
-
-`credentialsAnnotation` selects the credentials that the injector uses to retrieve the DSV Secret.
-If the credentials are present, it must map to Client Credential and Tenant mapping.
-The injector will use the _default_ Credential and Tenant mapping unless the `credentialsAnnotation` is declared.
-The `setAnnotation`, `addAnnotation` and `updateAnnotation`,
-must contain the path to the DSV Secret that the injector will use to mutate the Kubernetes Secret.
-
-- `addAnnotation` adds missing fields without overwriting or removing existing fields.
-- `updateAnnotation` adds and overwrites existing fields but does not remove fields.
-- `setAnnotation` overwrites fields and removes fields that do not exist in the DSV Secret.
-  NOTE: A Kubernetes Secret should specify only one of the "add," "update,"
-  or "set" annotations.
-  The order of precedence is `setAnnotation`,
-  then `addAnnotation`, then `updateAnnotation` when multiple are present.
-
-### Examples
-
-```yaml
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: example-secret
-  annotations:
-    dsv.delinea.com/credentials: app1
-    dsv.delinea.com/set-secret: /test/secret
-type: Opaque
-data:
-  username: dW5tb2RpZmllZC11c2VybmFtZQ==
-  domain: dW5tb2RpZmllZC1kb21haW4=
-  password: dW5tb2RpZmllZC1wYXNzd29yZA==
-```
-
-The above example specifies credentials,
-so a mapping for those credentials must exist in the current webhook configuration.
-It uses the `setAnnotation`,
-so the data in the injector will overwrite the existing contents of the Kubernetes Secret;
-if `/test/secret` contains a `username` and `password` but no `domain`,
-then the Kubernetes Secret would get the `username` and `password` from the DSV Secret Data but,
-the injector will remove the `domain` field.
-There are more examples in the `examples` directory.
-They show how the different annotations work.
-
-## Other Dev Tools
-
-Use Stern to easily stream cross namespace logs with the `dsv-filter-selector` by running:
-
-- To grab Stern binary, you can run `$(curl -fSSl https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64 -o ./stern) && sudo chmod +x ./stern && sudo mv ./stern /usr/local/bin`. (Modify version as you need)
-- For all pods in the namespace run `stern --kubeconfig .cache/config --namespace dsv --timestamps .`
-- For pods with the selector run `stern --kubeconfig .cache/config --namespace dsv --timestamps --selector 'dsv-filter-name in (dsv-syncer, dsv-injector)'`
+See details in [local-testing](docs/local-testing.md)
 
 ## Reference Mage Tasks
 
 > Manually updated, for most recent Mage tasks, run `mage -l`.
 
-| Target | Description        |
-| ------ | ------------------ |
-| clean  | up after yourself. |
-
-|
-| gittools:init | ⚙️ Init runs all required steps to use this package.
-|
-| go:doctor | 🏥 Doctor will provide config details.
-|
-| go:fix | 🔎 Run golangci-lint and apply any auto-fix.
-|
-| go:fmt | ✨ Fmt runs gofumpt.
-|
-| go:init | ⚙️ Init runs all required steps to use this package.
-|
-| go:lint | 🔎 Run golangci-lint without fixing.
-|
-| go:lintConfig | 🏥 LintConfig will return output of golangci-lint config.
-|
-| go:test | 🧪 Run go test.
-|
-| go:testSum | 🧪 Run gotestsum (Params: Path just like you pass to go test, ie ./..., pkg/, etc ). |
-| go:tidy | 🧹 Tidy tidies.
-|
-| go:wrap | ✨ Wrap runs golines powered by gofumpt.
-|
-| helm:docs | generates helm documentation using `helm-doc` tool.
-|
-| helm:init | ⚙️ Init sets up the required files to allow for local editing/overriding from CacheDirectory.
-|
-| helm:install | 🚀 Install uses Helm to install the chart.
-|
-| helm:lint | 🔍 Lint uses Helm to lint the chart for issues.
-|
-| helm:render | 💾 Render uses Helm to output rendered yaml for testing helm integration.
-|
-| helm:uninstall | 🚀 Uninstall uses Helm to uninstall the chart.
-|
-| init | runs multiple tasks to initialize all the requirements for running a project for a new contributor.
-|
-| job:redeploy | removes kubernetes resources and helm charts and then redeploys with log streaming by default.
-|
-| job:setup | initializes all the required steps for the cluster creation, initial helm chart copies, and kubeconfig copies.
-|
-| k8s:apply | applies a kubernetes manifest.
-|
-| k8s:delete | Apply applies a kubernetes manifest.
-|
-| k8s:init | copies the k8 yaml manifest files from the examples directory to the cache directory for editing and linking in integration testing.
-|
-| k8s:logs | streams logs until canceled for the dsv syncing jobs, based on the label `dsv.delinea.com: syncer`. |
-| kind:destroy | 🗑️ Destroy tears down the Kind cluster.
-|
-| kind:init | ➕ Create creates a new Kind cluster and populates a kubeconfig in cachedirectory.
-|
-| precommit:commit | 🧪 Commit runs pre-commit checks using pre-commit.
-|
-| precommit:init | ⚙️ Init configures precommit hooks.
-|
-| precommit:prepush | 🧪 Push runs pre-push checks using pre-commit.
-|
-| precommit:uninstall | ✖ Uninstall removes the pre-commit hooks.
-|
-| secrets:detect | 🔐 Detect scans for secret violations with gitleaks without git consideration.
-|
-| secrets:protect | 🔐 Protect scans the staged artifacts for violations.
-|
+| Target           | Description                                                                                                                          |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| build            | 🔨 Build builds the project for the current platform.                                                                                |
+| buildAll         | 🔨 BuildAll builds all the binaries defined in the project, for all platforms.                                                       |
+| clean            | up after yourself.                                                                                                                   |
+| go:doctor        | 🏥 Doctor will provide config details.                                                                                               |
+| go:fix           | 🔎 Run golangci-lint and apply any auto-fix.                                                                                         |
+| go:fmt           | ✨ Fmt runs gofumpt.                                                                                                                 |
+| go:init          | ⚙️ Init runs all required steps to use this package.                                                                                 |
+| go:lint          | 🔎 Run golangci-lint without fixing.                                                                                                 |
+| go:lintConfig    | 🏥 LintConfig will return output of golangci-lint config.                                                                            |
+| go:test          | 🧪 Run go test.                                                                                                                      |
+| go:testSum       | 🧪 Run gotestsum (Params: Path just like you pass to go test, ie ./..., pkg/, etc ).                                                 |
+| go:tidy          | 🧹 Tidy tidies.                                                                                                                      |
+| go:wrap          | ✨ Wrap runs golines powered by gofumpt.                                                                                             |
+| helm:docs        | generates helm documentation using `helm-doc` tool.                                                                                  |
+| helm:init        | ⚙️ Init sets up the required files to allow for local editing/overriding from CacheDirectory.                                        |
+| helm:install     | 🚀 Install uses Helm to install the chart.                                                                                           |
+| helm:lint        | 🔍 Lint uses Helm to lint the chart for issues.                                                                                      |
+| helm:render      | 💾 Render uses Helm to output rendered yaml for testing helm integration.                                                            |
+| helm:uninstall   | 🚀 Uninstall uses Helm to uninstall the chart.                                                                                       |
+| init             | runs multiple tasks to initialize all the requirements for running a project for a new contributor.                                  |
+| installTrunk     | installs trunk.io tooling if it isn't already found.                                                                                 |
+| job:init         | runs the setup tasks to initialize the local resources and files, without trying to apply yet.                                       |
+| job:redeploy     | removes kubernetes resources and helm charts and then redeploys with log streaming by default.                                       |
+| k8s:apply        | applies a kubernetes manifest.                                                                                                       |
+| k8s:delete       | Apply applies a kubernetes manifest.                                                                                                 |
+| k8s:init         | copies the k8 yaml manifest files from the examples directory to the cache directory for editing and linking in integration testing. |
+| k8s:logs         | streams logs until canceled for the dsv syncing jobs, based on the label `dsv.delinea.com: syncer`.                                  |
+| kind:destroy     | 🗑️ Destroy tears down the Kind cluster.                                                                                              |
+| kind:init        | ➕ Create creates a new Kind cluster and populates a kubeconfig in cachedirectory.                                                   |
+| minikube:destroy | 🗑️ Destroy tears down the Kind cluster.                                                                                              |
+| minikube:init    | ➕ Create creates a new Minikube cluster and populates a kubeconfig in cachedirectory.                                               |
+| release          | 🔨 Release generates a release for the current platform.                                                                             |
+| trunkInit        | ensures the required runtimes are installed.                                                                                         |
 
 ## Contributors
 
@@ -555,3 +155,12 @@ Migus</b></sub></a><br /><a href="https://github.com/DelineaXPM/dsv-k8s/commits?
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification.
 Contributions of any kind welcome!
+
+[kubernetes]: https://kubernetes.io/
+[mutating-webhook]: https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/#admission-webhooks
+[annotation]: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+[dsv-go-sdk]: https://github.com/DelineaXPM/dsv-sdk-go
+[docker-desktop]: https://www.docker.com/products/docker-desktop/
+[minikube]: https://minikube.sigs.k8s.io/
+[openshift]: https://www.redhat.com/en/technologies/cloud-computing/openshift
+[microk8s]: https://microk8s.io/

--- a/docs/assets/info-markup-default-creds.svg
+++ b/docs/assets/info-markup-default-creds.svg
@@ -1,0 +1,74 @@
+<svg fill="none" viewBox="0 0 800 100" width="800" height="100" xmlns="http://www.w3.org/2000/svg">
+    <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <style>
+                .container {
+                    border-radius: 2px;
+                    padding: 16px 16px;
+                    background-color: #BDE5F8;
+                    border: 1px solid rgba(0, 82, 155, 0.2);
+                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+                }
+
+                .container svg {
+                    width: 16px;
+                    height: 16px;
+                    vertical-align: text-top;
+                }
+
+                .container .message {
+                    color: #00529B;
+                    font-size: 1.2rem;
+                    margin-left: 1rem;
+                }
+            </style>
+            <div class="container">
+                <div class="header">
+                    <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" fill="#00529B" viewBox="0 0 512 512"
+                        style="enable-background:new 0 0 512 512;" xml:space="preserve">
+                        <g>
+                            <g>
+                                <path d="M437.02,74.98C388.667,26.629,324.38,0,256,0S123.333,26.629,74.98,74.98C26.629,123.333,0,187.62,0,256
+			s26.629,132.667,74.98,181.02C123.333,485.371,187.62,512,256,512s132.667-26.629,181.02-74.98
+			C485.371,388.667,512,324.38,512,256S485.371,123.333,437.02,74.98z M256,70c30.327,0,55,24.673,55,55c0,30.327-24.673,55-55,55
+			c-30.327,0-55-24.673-55-55C201,94.673,225.673,70,256,70z M326,420H186v-30h30V240h-30v-30h110v180h30V420z" />
+                            </g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                    </svg>
+                    <span class="message">The injector uses the <i>default</i> credentials when mutating a Kubernetes Secret without a credentialAnnotation.</span>
+                </div>
+            </div>
+        </div>
+    </foreignObject>
+</svg>

--- a/docs/assets/random-dont-need-to-install.svg
+++ b/docs/assets/random-dont-need-to-install.svg
@@ -1,0 +1,75 @@
+<svg fill="none" viewBox="0 0 800 100" width="800" height="100" xmlns="http://www.w3.org/2000/svg">
+    <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <style>
+                .container {
+                    border-radius: 2px;
+                    padding: 16px 16px;
+                    background-color: #DFF2BF;
+                    border: 1px solid rgba(79, 138, 16, 0.2);
+                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+                }
+
+                .container svg {
+                    width: 16px;
+                    height: 16px;
+                    vertical-align: text-top;
+                }
+
+                .container .message {
+                    color: #4F8A10;
+                    font-size: 1.2rem;
+                    margin-left: 1rem;
+                }
+            </style>
+            <div class="container">
+                <div class="header">
+                    <svg version="1.1" id="Capa_1" xmlns="http://www.w3.org/2000/svg"
+                        xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 477.867 477.867"
+                        fill="#4F8A10" style="enable-background:new 0 0 477.867 477.867;" xml:space="preserve">
+                        <g>
+                            <g>
+                                <path d="M238.933,0C106.974,0,0,106.974,0,238.933s106.974,238.933,238.933,238.933s238.933-106.974,238.933-238.933
+			C477.726,107.033,370.834,0.141,238.933,0z M370.466,165.666L199.799,336.333c-6.665,6.663-17.468,6.663-24.132,0l-68.267-68.267
+			c-6.78-6.548-6.968-17.352-0.42-24.132c6.548-6.78,17.352-6.968,24.132-0.42c0.142,0.138,0.282,0.277,0.42,0.42l56.201,56.201
+			l158.601-158.601c6.78-6.548,17.584-6.36,24.132,0.419C376.854,148.567,376.854,159.052,370.466,165.666z" />
+                            </g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                        <g>
+                        </g>
+                    </svg>
+                    <span class="message"><b>Save Yourself Some Work</b><br/>
+                    The image is on Docker Hub. You don't have to build and run this locally to use the helm charts.</span>
+                </div>
+            </div>
+        </div>
+    </foreignObject>
+</svg>

--- a/docs/assets/warning-app1-required-for-tests.svg
+++ b/docs/assets/warning-app1-required-for-tests.svg
@@ -1,0 +1,45 @@
+<svg fill="none" viewBox="0 0 800 100" width="800" height="100" xmlns="http://www.w3.org/2000/svg">
+    <foreignObject width="100%" height="100%">
+        <div xmlns="http://www.w3.org/1999/xhtml">
+            <style>
+                .container {
+                    border-radius: 2px;
+                    padding: 16px 16px;
+                    background-color: #FEEFB3;
+                    border: 1px solid rgba(159,96,0,0.2);
+                    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto;
+                }
+
+                .container svg {
+                    width: 16px;
+                    height: 16px;
+                    vertical-align: text-top;
+                }
+
+                .container .message {
+                    color: #9F6000;
+                    font-size: 1.2rem;
+                    margin-left: 1rem;
+                }
+            </style>
+            <div class="container">
+                <div class="header">
+                    <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="512" fill="#9F6000" height="512">
+                        <g id="Tombstone">
+                            <path d="M26,22a2,2,0,0,0-2-2H22v4h2A2,2,0,0,0,26,22Z" />
+                            <path d="M42,22a2,2,0,0,0-2-2H38v4h2A2,2,0,0,0,42,22Z" />
+                            <path d="M14.794,57.2,8.032,60H55.968l-6.762-2.8A44.716,44.716,0,0,0,14.794,57.2Z" />
+                            <path
+                                d="M8,54.858A4,4,0,0,0,11,51V48a1,1,0,0,0-2,0v3a1.993,1.993,0,0,1-1,1.722V48a1,1,0,0,0-2,0v4.722A1.993,1.993,0,0,1,5,51V48a1,1,0,0,0-2,0v3a4,4,0,0,0,3,3.858v3.9l2-.828Z" />
+                            <path
+                                d="M56,54.858A4,4,0,0,1,53,51V48a1,1,0,0,1,2,0v3a1.993,1.993,0,0,0,1,1.722V48a1,1,0,0,1,2,0v4.722A1.993,1.993,0,0,0,59,51V48a1,1,0,0,1,2,0v3a4,4,0,0,1-3,3.858v3.9l-2-.828Z" />
+                            <path
+                                d="M15,54.98a46.641,46.641,0,0,1,34,0V21a17,17,0,0,0-34,0ZM40,42H24a1,1,0,0,1,0-2H40a1,1,0,0,1,0,2ZM36,19a1,1,0,0,1,1-1h3a4,4,0,0,1,0,8H38v5a1,1,0,0,1-2,0Zm-5,0a1,1,0,0,1,2,0V31a1,1,0,0,1-2,0ZM20,19a1,1,0,0,1,1-1h3a4,4,0,0,1,.813,7.916l3.019,4.529a1,1,0,0,1-1.664,1.11L22.465,26H22v5a1,1,0,0,1-2,0Zm1,17H43a1,1,0,0,1,0,2H21a1,1,0,0,1,0-2Z" />
+                        </g>
+                    </svg>
+                    <span class="message">The tests are hardcoded to expect <code>app1</code>, so ensure this is configured for the local tests.</span>
+                </div>
+            </div>
+        </div>
+    </foreignObject>
+</svg>

--- a/docs/configure.md
+++ b/docs/configure.md
@@ -1,0 +1,66 @@
+# Configure
+
+This focuses on the DSV configuration required to use with Kubernetes.
+This applies to both local testing Kubernetes and your own seperate cluster.
+
+## JSON Credentials for Helm Install
+
+The configuration requires a JSON formatted list of Client Credential and Tenant mappings.
+
+The name of the credential (such as `app1` or `default`) is used for matching the annontated credential to the right credentials file to use to connect to the connect tenant.
+
+You can place your temporary config in `.cache/credentials.json` as this is ignored by git, so that you can run the helm install command manually if you aren't doing local development.
+
+<img src="assets/info-markup-default-creds.svg">
+
+```json
+{
+  "app1": {
+    "credentials": {
+      "clientId": "93d866d4-635f-4d4e-9ce3-0ef7f879f319",
+      "clientSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxx-xxxxx"
+    },
+    "tenant": "mytenant"
+  },
+  "default": {
+    "credentials": {
+      "clientId": "64241412-3934-4aed-af26-95b1eaba0e6a",
+      "clientSecret": "xxxxxxxxxxxxxxxxxxxxxxxxx-xxxxxxxxxxx-xxxxx"
+    },
+    "tenant": "mytenant"
+  }
+}
+```
+
+This would be referenced by a Kubernetes secret with annontations like:
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: user-domain-pass
+  annotations:
+    dsv.delinea.com/credentials: app1
+    dsv.delinea.com/set-secret: 'k8s:sync:test'
+```
+
+## Configuring Credentials in Kubernetes To Talk to DSV
+
+## Configuring DSV
+
+The following is an example of the steps to setup for testing, but can be modified to support your use case.
+
+Create the role that will allow creating a client for programmatic access
+
+```shell
+dsv role create --name 'k8s' --desc 'test profile for k8s'
+dsv secret create --path 'k8s:sync:test' --data '{"password": "admin","username": "admin"}'
+```
+
+Create a policy that allows the local user to read the secret, modify this to the correct user/group mapping:
+
+```shell
+dsv policy create -- actions 'read' --path 'secrets:k8s' --desc 'test access to secret' --resources 'secrets:k8s:<.*>' --subjects 'roles:k8s'
+dsv client create --role k8s
+```

--- a/docs/devcontainer.md
+++ b/docs/devcontainer.md
@@ -1,21 +1,4 @@
-# Devcontainer Based Setup
-
-- [Devcontainer Based Setup](#devcontainer-based-setup)
-  - [Prerequisites](#prerequisites)
-  - [I'm starting from scratch](#im-starting-from-scratch)
-    - [Windows](#windows)
-    - [MacOS](#macos)
-    - [Linux](#linux)
-    - [After You've Setup VSCode](#after-youve-setup-vscode)
-  - [I already use devcontainers](#i-already-use-devcontainers)
-  - [Spin It Up](#spin-it-up)
-    - [After Devcontainer Loads](#after-devcontainer-loads)
-  - [Working With Kind \& Stack Locally](#working-with-kind--stack-locally)
-    - [Kind](#kind)
-  - [Troubleshooting](#troubleshooting)
-  - [Error With Permissions On Go Directories](#error-with-permissions-on-go-directories)
-    - [Mismatch With Checksum for Go Modules](#mismatch-with-checksum-for-go-modules)
-    - [Connecting to Services Outside of devcontainer](#connecting-to-services-outside-of-devcontainer)
+# Devcontainer
 
 ## Prerequisites
 
@@ -87,42 +70,3 @@ This includes (for updated info just look at dockerfile):
    1. If it's not, run `sudo .devcontainer/library-scripts/go-debian.sh "1.19"`
 1. Run setup task:
    - Using CLI: Run `mage init`
-
-## Working With Kind & Stack Locally
-
-> **_NOTE_**
-> For any tasks get more help with `-h`, for example, run `mage -h k8s:init`
-
-### Kind
-
-For local development, Mage tasks have been created to automate most of the setup and usage for local testing.
-
-- Ensure your local `configs/credentials.json` exists.
-- run `mage job:init` to setup a local kind cluster, initial local copies of the helm chart and kubernetes manifest files.
-- Modify the `.cache/dsv-injector/values.yaml` with the embedded credentials.json contents matching your `configs/credentials.json`.
-- Modify the `.cache/manifests/*.yaml` files to match the credentials you want to test against.
-- To deploy (or redeploy after changes) all the helm charts and kuberenetes manifests run `mage job:redeploy`.
-
-## Troubleshooting
-
-## Error With Permissions On Go Directories
-
-Clear the directories with `rm -rf /home/vscode/go` and then try `mage init` to redownload packages.
-
-> Known issue: Haven't figured out why this is being set incorrectly yet
-
-### Mismatch With Checksum for Go Modules
-
-- Run `go clean -modcache && go mod tidy`.
-
-### Connecting to Services Outside of devcontainer
-
-You are in an isolated, self-contained Docker setup.
-The ports internally aren't the same as externally in your host OS.
-If the port forward isn't discovered automatically, enable it yourself, by using the port forward tab (next to the terminal tab).
-
-1. You should see a port forward once the services are up (next to the terminal button in the bottom pane).
-   1. If the click to open url doesn't work, try accessing the path manually, and ensure it is `https`.
-      Example: `https://127.0.0.1:9999`
-
-You can choose the external port to access, or even click on it in the tab and it will open in your host for you.

--- a/docs/developer-debugging.md
+++ b/docs/developer-debugging.md
@@ -1,0 +1,55 @@
+# Developer Debugging
+
+This documentation comes from the original `make` driven build process.
+It hasn't been migrated to `mage` and will be noted here unless deprecated.
+
+## Host (for debugging)
+
+Per above, typically, the injector runs as a POD in the cluster but running it on the host makes debugging easier.
+
+```sh
+make install-host EXTERNAL_NAME=laptop.mywifi.net CA_BUNDLE=$(cat /path/to/ca.crt | base64 -w0 -)
+```
+
+For it to work:
+
+- The certificate that the injector presents must validate against the `$(CA_BUNDLE)`.
+- The certificate must also have a Subject Alternative Name for `$(INJECTOR_NAME).$(NAMESPACE).svc`.
+  By default that's `dsv-injector.dsv.svc`.
+
+- The `$(EXTERNAL_NAME)` is a required argument, and the name itself must be resolvable _inside_ the cluster.
+  **localhost will not work**.
+
+If the `$(CA_BUNDLE)` is argument is omitted, `make` will attempt to extract it from `kubectl config`:
+
+```make
+install-host: CA_BUNDLE_KUBE_CONFIG_INDEX = 0
+install-host: CA_BUNDLE_JSON_PATH = {.clusters[$(CA_BUNDLE_KUBE_CONFIG_INDEX)].cluster.certificate-authority-data}
+install-host: CA_BUNDLE=$(shell $(KUBECTL) config view --raw -o jsonpath='$(CA_BUNDLE_JSON_PATH)' | tr -d '"')
+
+```
+
+which will make:
+
+```sh
+kubectl config view --raw -o jsonpath='{.clusters[0].cluster.certificate-authority-data}' | tr -d '"'
+```
+
+Optionally set `$(CA_BUNDLE_KUBE_CONFIG_INDEX)` to use `1`, to use the second cluster in your configuration,
+`2` for the third and so on.
+ℹ️ All this assumes that the injector uses a certificate signed by the cluster CA.
+There are several options like [cert-manager](https://cert-manager.io/)
+for getting cluster-signed certs, however,
+this simple [bash script](https://gist.github.com/amigus/b4e6e642f88e756be1996e44a1c35349)
+will request and grant a suitable certificate from the cluster using cURL and OpenSSL.
+To use it:
+
+```sh
+get_k8s_cert.sh -n dsv-injector -N dsv
+```
+
+Now run it:
+
+```sh
+./dsv-injector -cert ./dsv-injector.pem -key ./dsv-injector.key -credentials ./configs/credentials.json -address :8543
+```

--- a/docs/developer-reference.md
+++ b/docs/developer-reference.md
@@ -1,0 +1,31 @@
+# Devcontainer Based Setup
+
+- [Devcontainer Based Setup](#devcontainer-based-setup)
+  - [Troubleshooting](#troubleshooting)
+  - [Error With Permissions On Go Directories](#error-with-permissions-on-go-directories)
+    - [Mismatch With Checksum for Go Modules](#mismatch-with-checksum-for-go-modules)
+    - [Connecting to Services Outside of devcontainer](#connecting-to-services-outside-of-devcontainer)
+
+## Troubleshooting
+
+## Error With Permissions On Go Directories
+
+Clear the directories with `rm -rf /home/vscode/go` and then try `mage init` to redownload packages.
+
+> Known issue: Haven't figured out why this is being set incorrectly yet
+
+### Mismatch With Checksum for Go Modules
+
+- Run `go clean -modcache && go mod tidy`.
+
+### Connecting to Services Outside of devcontainer
+
+You are in an isolated, self-contained Docker setup.
+The ports internally aren't the same as externally in your host OS.
+If the port forward isn't discovered automatically, enable it yourself, by using the port forward tab (next to the terminal tab).
+
+1. You should see a port forward once the services are up (next to the terminal button in the bottom pane).
+   1. If the click to open url doesn't work, try accessing the path manually, and ensure it is `https`.
+      Example: `https://127.0.0.1:9999`
+
+You can choose the external port to access, or even click on it in the tab and it will open in your host for you.

--- a/docs/helm-install.md
+++ b/docs/helm-install.md
@@ -1,0 +1,30 @@
+## Helm Install
+
+Installation of charts into the a cluster requires [Helm](https://helm.sh).
+
+There are two separate charts for the `dsv-injector` and the `dsv-syncer`.
+
+- The `dsv-injector` chart imports `credentials.json` from the filesystem and stores it in a Kubernetes Secret.
+- The `dsv-syncer` chart refers to that Secret _instead of creating its own_.
+
+See [configure](configure.md#json-credentials-for-helm-install)
+
+```shell
+NAMESPACE='testing'
+CREDENTIALS_JSON_FILE='.cache/credentials.json'
+IMAGE_REPOSITORY='docker.io/delineaxpm/dsv-k8s'
+
+helm install
+     --namespace $NAMESPACE
+     --create-namespace \
+     --set-file credentialsJson=${CREDENTIALS_JSON_FILE} \
+      --set image.repository=${IMAGE_REPOSITORY} \
+     dsv-injector ./charts/dsv-injector
+
+helm install
+     --namespace $NAMESPACE
+     --create-namespace \
+     --set-file credentialsJson=${CREDENTIALS_JSON_FILE} \
+      --set image.repository=${IMAGE_REPOSITORY} \
+     dsv-syncer ./charts/dsv-syncer
+```

--- a/docs/local-cli-invoke.md
+++ b/docs/local-cli-invoke.md
@@ -1,0 +1,35 @@
+# Local CLI Invoke
+
+The cli can be invoked locally.
+
+The injector uses the HTTPS server built-in to the Golang [http](https://pkg.go.dev/net/http)
+package to host the Kubernetes Mutating Webhook Webservice.
+
+```bash
+$ ./dsv-injector -h
+Usage of ./dsv-injector:
+  -address string
+        the address to listen on, e.g., 'localhost:8080' or ':8443' (default ":18543")
+  -cert string
+        the path of the public certificate file in PEM format (default "tls/cert.pem")
+  -credentials string
+        the path of JSON formatted credentials file (default "credentials/config.json")
+  -key string
+        the path of the private key file in PEM format (default "tls/key.pem")
+```
+
+Thus the injector can run "anywhere," but, typically,
+the injector runs as a POD in the Kubernetes cluster that uses it.
+The syncer is a simple Golang executable.
+It typically runs as a Kubernetes CronJob, but it will run outside the cluster.
+
+```bash
+$ ./dsv-syncer -h
+Usage of ./dsv-syncer:
+  -credentials string
+        the path of JSON formatted credentials file (default "credentials/config.json")
+  -kubeConfig string
+        the Kubernetes Client API configuration file; ignored when running in-cluster (default "/home/user/.kube/config")
+  -namespace string
+        the Kubernetes namespace containing the Secrets to sync; "" (the default) for all namespaces
+```

--- a/docs/local-kubernetes.md
+++ b/docs/local-kubernetes.md
@@ -1,0 +1,51 @@
+# Local Kubernetes
+
+For easier development workflow, the project has prebuilt tasks for both minikube and kind kubernetes tools.
+
+As of 2023-02, the default behavior is to use minikube since it handles updating the kubeconfig locally a little more consistently in the tests run.
+
+## Working With Kubernetes & Stack Locally
+
+> **_NOTE_**
+> For any tasks get more help with `-h`, for example, run `mage -h k8s:init`
+
+For local development, Mage tasks have been created to automate most of the setup and usage for local testing.
+
+- Ensure your local `configs/credentials.json` exists.
+- run `mage job:init` to setup a local k8s cluster, initial local copies of the helm chart and kubernetes manifest files.
+- Modify the `.cache/dsv-injector/values.yaml` with the embedded credentials.json contents matching your `configs/credentials.json`.
+- Modify the `.cache/manifests/*.yaml` files to match the credentials you want to test against.
+- To deploy (or redeploy after changes) all the helm charts and kuberenetes manifests run `mage job:redeploy`.
+
+## Using Minikube With VM Driver
+
+<details>
+<summary>ℹ️ Using Minikube With VM Driver</summary>
+
+To deploy to Minikube set-up with the VM driver, e.g., Linux [kvm2](https://minikube.sigs.k8s.io/docs/drivers/kvm2/)
+or Microsoft [Hyper-V](https://minikube.sigs.k8s.io/docs/drivers/hyperv/),
+enable the Minikube built-in registry and use it to make the image available to the Minikube VM:
+
+```shell
+minikube addons enable registry
+```
+
+❗NOTE: run Minikube [tunnel](https://minikube.sigs.k8s.io/docs/commands/tunnel/)
+in a separate terminal to make the registry service available to the host.
+
+```shell
+minikube tunnel
+```
+
+_It will run continuously, and stopping it will render the registry inaccessible._
+
+Next, get the _host:port_ of the registry:
+
+```shell
+kubectl get -n kube-system service registry -o jsonpath="{.spec.clusterIP}{':'}{.spec.ports[0].port}"
+```
+
+Finally, follow the [Remote Cluster](#remote-cluster)
+instructions using it as `$(REGISTRY)`
+
+</details>

--- a/docs/local-testing.md
+++ b/docs/local-testing.md
@@ -1,0 +1,33 @@
+# Local Testing
+
+## First Time Setup
+
+- A valid DSV tenant.
+- Creation of a dsv secret and the configured client credentials to setup this.
+  See [configuring-dsv](configure.md#configuring-dsv)
+- The test helm chart values file to be updated with the credentials.
+  It's located at: `.cache/dsv-injector/values.yaml`.
+
+<img src="assets/warning-app1-required-for-tests.svg">
+
+## PENDING Contributor Improvements
+
+For dsv-team members, the goal is to load all this directly from a team vault. Right now this project has not been migrated to this, so you have to setup manually the first time.
+
+## Test Environment Configuration
+
+| Environment Variable                   | Default                          | Explanation                                                 |
+| -------------------------------------- | -------------------------------- | ----------------------------------------------------------- |
+| `DSV_K8S_TEST_CONFIG`                  | _none_                           | Contain a JSON string containing a valid `credentials.json` |
+| `DSV_K8S_TEST_SECRET_PATH`             | `/test/secret`                   | The path to the secret to test against in the vault         |
+| DEPRECATED: `DSV_K8S_TEST_CONFIG_FILE` | `../../configs/credentials.json` | The path to a valid `credentials.json`                      |
+
+ℹ️ NOTE: `DSV_K8S_TEST_CONFIG` takes precedence over `DSV_K8S_TEST_CONFIG_FILE`
+
+For example:
+
+```shell
+DSV_K8S_TEST_CONFIG='{"app1":{"credentials":{"clientId":"","clientSecret":""},"tenant":"mytenant"}}' \
+DSV_K8S_TEST_SECRET_PATH=my:test:secret \
+mage go:testsum ./...
+```

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,14 +1,5 @@
 # Release
 
-## First Time Setup
-
-- Run `mage init` to install tooling.
-- Install [trunk](https://trunk.io/products/check) (quick install script: `curl https://get.trunk.io -fsSL | bash`)
-- Install [aqua](https://aquaproj.github.io/docs/tutorial-basics/quick-start#install-aqua) and have it configured in your path per directions.
-  - This will allow faster installs of project tooling by grabbing binaries for your platform more quickly (most of the time release binaries instead of building from source).
-- Run `aqua install` for tooling such as changie or others for the project.
-  - At this time, it expects you have to Go pre-installed.
-
 ## Release Notes
 
 This project uses an different approach to release, driving it from changelog and versioned changelog notes instead of tagging.

--- a/docs/setup-developer.md
+++ b/docs/setup-developer.md
@@ -1,0 +1,29 @@
+# Setup Developer
+
+## Dive In
+
+- [devcontainer/codespaces](devcontainer.md)
+- [Kubernetes](local-kubernetes.md)
+- [Project Setup](setup-project.md)
+
+## Other Dev Tools
+
+Use Stern to easily stream cross namespace logs with the `dsv-filter-selector` by running:
+
+Aqua installs this automatically, but if you want to do this manually grab from github releases like this
+
+```shell
+$(curl -fSSl https://github.com/wercker/stern/releases/download/1.11.0/stern_linux_amd64 -o ./stern) && sudo chmod +x ./stern && sudo mv ./stern /usr/local/bin
+```
+
+> Or use `brew install stern` or aqua.
+
+While `mage k8s:logs` will run this for you, manually you can invoke like this:
+
+```shell
+# For all pods in the namespace run
+stern --kubeconfig .cache/config --namespace dsv --timestamps .
+
+# For pods with the selector run
+stern --kubeconfig .cache/config --namespace dsv --timestamps --selector 'dsv-filter-name in (dsv-syncer, dsv-injector)'
+```

--- a/docs/setup-project.md
+++ b/docs/setup-project.md
@@ -1,0 +1,51 @@
+# Setup Project
+
+## Compatibility
+
+Linux & MacOS is supported out of the box for local development.
+Windows with WSL2 should also work fine.
+
+While the majority of this is cross-platform, the automatically linting and some other commands are only compatible with Linux/MacOS.
+
+## Overview
+
+- Make: Makefiles provide core automation from the original project.
+  This has slowly been phased out for the more robust Mage tasks.
+- Mage: Mage is a Go based automation alternative to Make and provides newer functionality for local Kind cluster setup, Go development tooling/linting, and more.
+  Use [aqua](#aqua) to automaticall install, or run `go install github.com/magefile/mage@latest`.
+- Run `mage -l` to list all available tasks, and `mage init` to setup developer tooling.
+  Get more detail on a task, if it's available by running `mage -h init`.
+
+## Initial Setup
+
+Most of the setup is automated via Mage, but there are some initial assumptions such as Go/Aqua expected to help automate the remaining setup.
+
+## When Using Without Devcontainer/Codespaces
+
+- Install Aqua
+  - Alternative: Manually ensure Go is installed.
+- Run `mage init` to install tooling.
+  - Done automatically by Mage -> Install [trunk](https://trunk.io/products/check) (quick install script: `curl https://get.trunk.io -fsSL | bash`)
+  - This will allow faster installs of project tooling by grabbing binaries for your platform more quickly (most of the time release binaries instead of building from source).
+
+## For someone creating a release
+
+## Aqua
+
+Install [aqua](https://aquaproj.github.io/docs/tutorial-basics/quick-start#install-aqua) and have it configured in your path per directions.
+
+Run `aqua install` for tooling such as changie or others for the project.
+
+Ensure your profile has this in it:
+
+```shell
+export PATH="${AQUA_ROOT_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/aquaproj-aqua}/bin:$PATH" # for those using aqua this will ensure it's in the path with all tools if loading from home
+```
+
+## Direnv
+
+This loads environment variables for the project automatically.
+
+Direnv: Default test values are loaded on macOS/Linux based system using [direnv](https://direnv.net/docs/installation.html).
+
+Run `direnv allow` in the directory to load default env configuration for testing.

--- a/docs/using.md
+++ b/docs/using.md
@@ -1,0 +1,53 @@
+# Using
+
+Once installed, any correctly annotated Kubernetes Secrets are modified on create and update.
+
+The four annotations that affect the behavior of the webhook are:
+
+```golang
+const(
+    credentialsAnnotation = "dsv.delinea.com/credentials"
+    setAnnotation         = "dsv.delinea.com/set-secret"
+    addAnnotation         = "dsv.delinea.com/add-to-secret"
+    updateAnnotation      = "dsv.delinea.com/update-secret"
+)
+```
+
+`credentialsAnnotation` selects the credentials that the injector uses to retrieve the DSV Secret.
+If the credentials are present, it must map to Client Credential and Tenant mapping.
+The injector will use the _default_ Credential and Tenant mapping unless the `credentialsAnnotation` is declared.
+The `setAnnotation`, `addAnnotation` and `updateAnnotation`, must contain the path to the DSV Secret that the injector will use to mutate the Kubernetes Secret.
+
+- `addAnnotation` adds missing fields without overwriting or removing existing fields.
+- `updateAnnotation` adds and overwrites existing fields but does not remove fields.
+- `setAnnotation` overwrites fields and removes fields that do not exist in the DSV Secret.
+  NOTE: A Kubernetes Secret should specify only one of the "add," "update,"
+  or "set" annotations.
+  The order of precedence is `setAnnotation`,
+  then `addAnnotation`, then `updateAnnotation` when multiple are present.
+
+## Examples
+
+```yaml
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: example-secret
+  annotations:
+    dsv.delinea.com/credentials: app1
+    dsv.delinea.com/set-secret: test:secret
+type: Opaque
+data:
+  username:
+  domain:
+  password:
+```
+
+The above example specifies credentials, so a mapping for those credentials must exist in the current webhook configuration.
+It uses the `setAnnotation`, so the data in the injector will overwrite the existing contents of the Kubernetes Secret.
+
+If `/test/secret` contains a `username` and `password` but no `domain`, then the k8s secret would get the `username` and `password` from dsv secret data and the injector will remove the `domain` field.
+
+There are more examples in the `examples` directory.
+They show how the different annotations work.

--- a/magefiles/helm/helm.mage.go
+++ b/magefiles/helm/helm.mage.go
@@ -75,6 +75,7 @@ func (Helm) Init() error {
 // newClient returns a helm client, and allows passing a kubeconfig path.
 // By default it just uses what's set in the environment.
 // If kubeconfig is provided then by default this should be using the local kind cluster setup.
+//
 //nolint:unparam // Allow initially. I placed in case I want to allow running against a target instance other than kind to allow overriding. Add an env check for KUBECONFIG and allow override then.
 func newClient( //nolint:ireturn // Ignore for this helm project
 	namespace, kubeconfig string,

--- a/magefiles/jobs.mage.go
+++ b/magefiles/jobs.mage.go
@@ -26,19 +26,6 @@ func (Job) Init() {
 	)
 }
 
-// Setup runs all the initialization tasks, in addition to installing the helm chart and kubeconfig files.
-func (Job) Setup() {
-	pterm.DefaultSection.Println("(Job) Setup()")
-	mg.SerialDeps(
-		minikube.Minikube{}.Init,
-		k8s.K8s{}.Init,
-		helm.Helm{}.Init,
-		mg.F(k8s.K8s{}.Apply, constants.CacheManifestDirectory),
-		helm.Helm{}.Install,
-		k8s.K8s{}.Logs,
-	)
-}
-
 // Redeploy removes kubernetes resources and helm charts and then redeploys with log streaming by default.
 func (Job) Redeploy() {
 	pterm.DefaultSection.Println("(Job) Redeploy()")


### PR DESCRIPTION
- Improve docs organization by splitting out content into subfiles in `docs`.
- Remove references to tasks by make that have been replaced by `mage`.
- Refresh `mage` task list.
- Remove confusing `mage job:setup` when `mage job:init` and `mage job:redeploy` do the exact same thing.
- Only install Trunk if on macOS/Linux and also check for it already being installed before attempting to reinstall.
- Remove aqua env variable set in `.envrc` since this disruptes developer preferences.